### PR TITLE
Make StructConverter an abstract class to avoid runtime errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
         <release_version>0.1-SNAPSHOT</release_version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <kafkaconnect.version>2.7.0</kafkaconnect.version>
-        <junit.version>5.7.1</junit.version>
+        <kafkaconnect.version>3.7.2</kafkaconnect.version>
+        <junit.version>5.11.4</junit.version>
     </properties>
 
 
@@ -27,6 +27,7 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-runtime</artifactId>
             <version>${kafkaconnect.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -38,12 +39,6 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/github/baunz/kafka/connect/storage/StructConverter.java
+++ b/src/main/java/com/github/baunz/kafka/connect/storage/StructConverter.java
@@ -15,7 +15,7 @@ import java.util.Map;
 /**
  * Convert primitive values from and to ConnectData with a struct schema (as opposed to the matching primitive type)
  */
-public class StructConverter implements Converter {
+abstract class StructConverter implements Converter {
 
     private final Converter converter;
     private String fieldName;

--- a/src/test/java/com/github/baunz/kafka/connect/storage/StructConverterTest.java
+++ b/src/test/java/com/github/baunz/kafka/connect/storage/StructConverterTest.java
@@ -26,9 +26,7 @@ class StructConverterTest {
     }
 
     private Struct assertSchemaAndStruct(SchemaAndValue schemaAndValue) {
-
-        assertThat(schemaAndValue)
-                .isNotNull();
+        assertThat(schemaAndValue).isNotNull();
         Schema schema = schemaAndValue.schema();
         assertThat(schema).isNotNull();
         assertThat(schema.type()).isEqualTo(Schema.Type.STRUCT);


### PR DESCRIPTION
Otherwise kafka-connect will try to instantiate the class with a (missing) no-args constructor, because it extends the Converter interface. 